### PR TITLE
Update UnsupportedServer check

### DIFF
--- a/lib/redis_client.rb
+++ b/lib/redis_client.rb
@@ -686,7 +686,7 @@ class RedisClient
   rescue ConnectionError => error
     raise CannotConnectError, error.message, error.backtrace
   rescue CommandError => error
-    if error.message.include?("ERR unknown command `HELLO`")
+    if error.message.include?("ERR unknown command 'HELLO'")
       raise UnsupportedServer,
         "Your Redis server version is too old. redis-client requires Redis 6+. (#{config.server_url})"
     else

--- a/test/redis_client_test.rb
+++ b/test/redis_client_test.rb
@@ -52,7 +52,7 @@ class RedisClientTest < Minitest::Test
     fake_redis5_driver = Class.new(RedisClient::RubyConnection) do
       def call_pipelined(commands, *)
         if commands.any? { |c| c == ["HELLO", "3"] }
-          raise RedisClient::CommandError, "ERR unknown command `HELLO`, with args beginning with: `3`"
+          raise RedisClient::CommandError, "ERR unknown command 'HELLO', with args beginning with: '3'"
         else
           super
         end


### PR DESCRIPTION
* We are getting errors from redis like ERR unknown command 'HELLO' reported from the redis-client gem after updating our app to Sidekiq 7. After looking into the redis_client source code it looks like we test for that message to raise a more helpful UnsupportedServer error, but the string being tested for inlcludes backitcks where the error coming from the redis server includes single quotes
* Update test string to use single quotes so that the error coming from redis server will be matched and the UnsupportedServer error will be raised.